### PR TITLE
Fix input dir creation

### DIFF
--- a/windtunnel/windtunnel.py
+++ b/windtunnel/windtunnel.py
@@ -186,10 +186,6 @@ class WindTunnel:
 
         # Create a temporary directory
         temp_dir = tempfile.mkdtemp()
-        obj_dir = os.path.join(temp_dir, "constant/triSurface/")
-        os.makedirs(obj_dir)
-        object_path = os.path.join(obj_dir, "object.obj")
-        pre_processing.save_mesh_obj(self.object, object_path)
 
         inductiva.TemplateManager.render_dir(
             TEMPLATE_DIR,
@@ -200,9 +196,13 @@ class WindTunnel:
             num_subdomains=num_subdomains,
             area=self.object_area,
             length=self.object_length,
-            overwrite=True,
             **self._walls,
         )
+
+        obj_dir = os.path.join(temp_dir, "constant/triSurface/")
+        os.makedirs(obj_dir)
+        object_path = os.path.join(obj_dir, "object.obj")
+        pre_processing.save_mesh_obj(self.object, object_path)
 
         task = simulators.OpenFOAM().run(input_dir=temp_dir,
                                          on=mg,


### PR DESCRIPTION
The input dir with the object mesh was being created before creating the remaining files with the TemplateManager, causing the object mesh to be removed from the directory because of the `overwrite` behavior. This PR reverses the input dir creation order and removes "overwrite=True", which isn't needed.